### PR TITLE
PrepareMojo: Omit the legacy module descriptor (module.xml)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.monday-consulting.maven.plugins</groupId>
     <artifactId>fsm-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>2.0.3-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <name>fsm-maven-plugin</name>
     <url>https://www.monday-consulting.com</url>
 

--- a/src/it/prepare-dependency-with-classifier/verify.groovy
+++ b/src/it/prepare-dependency-with-classifier/verify.groovy
@@ -4,12 +4,12 @@ def fsmDir = new File(basedir, 'target/fsm-root')
 assert fsmDir.exists() : "The FSM root directory was not created"
 
 def moduleXmlFile = new File(fsmDir, 'META-INF/module.xml')
-assert moduleXmlFile.exists() : "The module.xml descriptor was not created"
+assert !moduleXmlFile.exists() : "The module.xml descriptor was created"
 def moduleIsolatedXmlFile = new File(fsmDir, 'META-INF/module-isolated.xml')
 assert moduleIsolatedXmlFile.exists() : "The module-isolated.xml descriptor was not created"
 
-def doc = new XmlSlurper().parse(moduleXmlFile)
-assert doc.version == 11 : "The module.xml version was not filtered"
+def doc = new XmlSlurper().parse(moduleIsolatedXmlFile)
+assert doc.version == 11 : "The module-isolated.xml version was not filtered"
 
 // verify commons-math3 is under <components> -> <web-app> -> <web-resources> and has the correct version
 def resource = doc.components.'web-app'.'web-resources'.childNodes().find { it.attributes().name = "org.xmlresolver:xmlresolver" }

--- a/src/it/prepare-example/verify.groovy
+++ b/src/it/prepare-example/verify.groovy
@@ -4,12 +4,12 @@ def fsmDir = new File(basedir, 'target/fsm-root')
 assert fsmDir.exists() : "The FSM root directory was not created"
 
 def moduleXmlFile = new File(fsmDir, 'META-INF/module.xml')
-assert moduleXmlFile.exists() : "The module.xml descriptor was not created"
+assert !moduleXmlFile.exists() : "The module.xml descriptor not created"
 def moduleIsolatedXmlFile = new File(fsmDir, 'META-INF/module-isolated.xml')
 assert moduleIsolatedXmlFile.exists() : "The module-isolated.xml descriptor was not created"
 
-def doc = new XmlSlurper().parse(moduleXmlFile)
-assert doc.version == 11 : "The module.xml version was not filtered"
+def doc = new XmlSlurper().parse(moduleIsolatedXmlFile)
+assert doc.version == 11 : "The module-isolated.xml version was not filtered"
 
 // verify commons-math3 is under <components> -> <web-app> -> <web-resources> and has the correct version
 def resource = doc.components.'web-app'.'web-resources'.childNodes().find { it.attributes().name = "org.apache.commons:commons-math3" }

--- a/src/it/prepare-with-legacy-descriptor/fsm/plugin.xml
+++ b/src/it/prepare-with-legacy-descriptor/fsm/plugin.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fsm-maven-plugin>
+    <modules>
+        <module>
+            <!-- use dependencies from this Maven project (../pom.xml) -->
+            <id>${project.groupId}:${project.artifactId}:${project.version}</id>
+            <dependencyTagValueInXml>unused</dependencyTagValueInXml>
+        </module>
+    </modules>
+</fsm-maven-plugin>

--- a/src/it/prepare-with-legacy-descriptor/fsm/prototype.module.xml
+++ b/src/it/prepare-with-legacy-descriptor/fsm/prototype.module.xml
@@ -1,0 +1,4 @@
+<module>
+    <name>Module with Legacy Descriptor</name>
+    <version>${project.version}</version>
+</module>

--- a/src/it/prepare-with-legacy-descriptor/pom.xml
+++ b/src/it/prepare-with-legacy-descriptor/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.monday-consulting.maven.plugins</groupId>
+    <artifactId>legacy-descriptor</artifactId>
+    <version>1</version>
+    <packaging>pom</packaging>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>fsm</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${basedir}/target/extra-resources</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>fsm</directory>
+                                    <filtering>true</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>com.monday-consulting.maven.plugins</groupId>
+                <artifactId>fsm-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <configXml>${basedir}/target/extra-resources/plugin.xml</configXml>
+                    <prototypeXml>${basedir}/target/extra-resources/prototype.module.xml</prototypeXml>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>prepare-module</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>prepare</goal>
+                        </goals>
+                        <configuration>
+                            <legacyModuleDescriptor>true</legacyModuleDescriptor>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/prepare-with-legacy-descriptor/verify.groovy
+++ b/src/it/prepare-with-legacy-descriptor/verify.groovy
@@ -1,0 +1,12 @@
+import groovy.xml.XmlSlurper
+
+def fsmDir = new File(basedir, 'target/fsm-root')
+assert fsmDir.exists() : "The FSM root directory was not created"
+
+def moduleXmlFile = new File(fsmDir, 'META-INF/module.xml')
+assert moduleXmlFile.exists() : "The module.xml descriptor was not created"
+def moduleIsolatedXmlFile = new File(fsmDir, 'META-INF/module-isolated.xml')
+assert moduleIsolatedXmlFile.exists() : "The module-isolated.xml descriptor was not created"
+
+def doc = new XmlSlurper().parse(moduleXmlFile)
+assert doc.version == 1 : "The module.xml version was not filtered"

--- a/src/it/prepare-with-runtime-dependency/verify.groovy
+++ b/src/it/prepare-with-runtime-dependency/verify.groovy
@@ -4,12 +4,12 @@ def fsmDir = new File(basedir, 'target/fsm-root')
 assert fsmDir.exists() : "The FSM root directory was not created"
 
 def moduleXmlFile = new File(fsmDir, 'META-INF/module.xml')
-assert moduleXmlFile.exists() : "The module.xml descriptor was not created"
+assert !moduleXmlFile.exists() : "The module.xml descriptor was created"
 def moduleIsolatedXmlFile = new File(fsmDir, 'META-INF/module-isolated.xml')
 assert moduleIsolatedXmlFile.exists() : "The module-isolated.xml descriptor was not created"
 
-def doc = new XmlSlurper().parse(moduleXmlFile)
-assert doc.version == 11 : "The module.xml version was not filtered"
+def doc = new XmlSlurper().parse(moduleIsolatedXmlFile)
+assert doc.version == 11 : "The module-isolated.xml version was not filtered"
 
 // verify lib is under <components> -> <web-app> -> <web-resources>
 def resource = doc.components.'web-app'.'web-resources'.childNodes().find { it.attributes().name = "com.fasterxml.jackson.core:jackson-databind" }

--- a/src/main/java/com/monday_consulting/maven/plugins/fsm/PrepareMojo.java
+++ b/src/main/java/com/monday_consulting/maven/plugins/fsm/PrepareMojo.java
@@ -30,6 +30,14 @@ class PrepareMojo extends BaseDependencyModuleMojo {
     private boolean attach;
 
     /**
+     * When true, also generates a legacy module.xml descriptor next to the default
+     * module-isolated.xml. This is intended for backward compatibility with older
+     * environments and tools that still expect a non-isolated module descriptor.
+     */
+    @Parameter(property = "legacyModuleDescriptor", defaultValue = "false", required = true)
+    private boolean legacyModuleDescriptor;
+
+    /**
      * The xml the module data write to.
      */
     @Parameter(name = "fsm-root", defaultValue = "fsm-root")
@@ -54,7 +62,7 @@ class PrepareMojo extends BaseDependencyModuleMojo {
             Files.createDirectories(fsmRootPath);
 
             ModuleXmlWriter moduleXmlWriter = new ModuleXmlWriter(getLog());
-            moduleXmlWriter.writeDomToTarget(fsmRootPath, prototype.getPrototypeDom());
+            moduleXmlWriter.writeDomToTarget(fsmRootPath, prototype.getPrototypeDom(), legacyModuleDescriptor);
 
             getLog().debug("Copying dependencies to " + fsmRootPath);
             new DependencyAssembler(getLog()).copyDependenciesForModuleAssembly(fsmRootPath, modules.values());

--- a/src/main/java/com/monday_consulting/maven/plugins/fsm/xml/ModuleXmlWriter.java
+++ b/src/main/java/com/monday_consulting/maven/plugins/fsm/xml/ModuleXmlWriter.java
@@ -22,27 +22,33 @@ public class ModuleXmlWriter {
     }
 
     /**
-     * Write a DOM-Tree to a target directory.
-     * This will create {@code ./META-INF/module.xml} and {@code ./META-INF/module-isolated.xml}
+     * Write a DOM tree into the given target directory.
+     * <p>
+     * This method always writes {@code ./META-INF/module-isolated.xml}. If {@code legacyModule} is
+     * {@code true}, it also writes a legacy descriptor at {@code ./META-INF/module.xml} (a copy of
+     * {@code module-isolated.xml}).
      *
-     * @param target target directory to write to
-     * @param dom    dom to write to file.
-     * @throws IOException in case of unexpected writer exceptions.
+     * @param target        the target directory to write to; it will be created along with {@code META-INF} if missing
+     * @param dom           the DOM to serialize into the descriptor file(s)
+     * @param legacyModule  when {@code true}, additionally create {@code module.xml} alongside {@code module-isolated.xml}
+     * @throws IOException  in case of unexpected writer exceptions
      */
-    public void writeDomToTarget(final Path target, final Xpp3Dom dom) throws IOException {
+    public void writeDomToTarget(final Path target, final Xpp3Dom dom, final boolean legacyModule) throws IOException {
         log.debug("Write TargetXml-File");
 
         final Path metaInf = target.resolve("META-INF");
         // ensure that the target directory exists
         Files.createDirectories(metaInf);
 
-        final Path moduleXml = metaInf.resolve("module.xml");
-        log.info("Writing module descriptor: " + moduleXml);
-        writeFile(moduleXml.toFile(), dom);
-
         final Path moduleIsolatedXml = metaInf.resolve("module-isolated.xml");
         log.info("Writing isolated module descriptor: " + moduleIsolatedXml);
-        Files.copy(moduleXml, moduleIsolatedXml, StandardCopyOption.REPLACE_EXISTING);
+        writeFile(moduleIsolatedXml.toFile(), dom);
+
+        if (legacyModule) {
+            final Path moduleXml = metaInf.resolve("module.xml");
+            log.info("Writing module descriptor: " + moduleXml);
+            Files.copy(moduleIsolatedXml, moduleXml, StandardCopyOption.REPLACE_EXISTING);
+        }
 
         log.debug("Dependencies written to Module-XML:\n\t" + dom);
     }


### PR DESCRIPTION
Changes the default behavior of the PrepareMojo: only the isolated descriptor `module-isolated.xml` will be written, and the legacy descriptor `module.xml` is omitted. FirstSpirit’s legacy mode has been discontinued, so the file is no longer needed.

The creation of the legacy descriptor can be enabled via configuration if needed:
`<legacyModuleDescriptor>true</legacyModuleDescriptor>`

Bumps plugin version to 2.1.0-SNAPSHOT.